### PR TITLE
ci: enable manual trigger for android build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- allow manual runs of Android CI build workflow via workflow_dispatch

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b80ad68e24832680b50b92b6fe6e03