### PR TITLE
chore(ci): update artifact action to v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -24,7 +24,7 @@ jobs:
     - name: Build Debug APK
       run: ./gradlew assembleDebug
     - name: Upload APK artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: shady-debug-apk
         path: app/build/outputs/apk/debug/*.apk


### PR DESCRIPTION
## Summary
- use actions/checkout@v4 and actions/setup-java@v4
- upgrade to actions/upload-artifact@v4 to avoid deprecation failure

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8589553ec8326b720e613908bca28