### PR TITLE
Fix Android CI to build with JDK 17 and upload debug APK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,18 +13,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up JDK 17 (Temurin)
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
-        distribution: 'temurin'
+        distribution: temurin
+        java-version: '17'
+        cache: gradle
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v3
     - name: Make Gradle executable
       run: chmod +x ./gradlew
     - name: Build Debug APK
-      run: ./gradlew assembleDebug
+      run: ./gradlew --no-daemon assembleDebug
     - name: Upload APK artifact
       uses: actions/upload-artifact@v4
       with:
-        name: shady-debug-apk
+        name: debug-apk
         path: app/build/outputs/apk/debug/*.apk
+        if-no-files-found: error


### PR DESCRIPTION
## Summary
- Build Android app on Java 17 and cache Gradle
- Install Android SDK and assemble debug APK
- Upload debug artifact

## Testing
- `./gradlew --version`
- `./gradlew --no-daemon assembleDebug` *(fails: incomplete output, likely missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b8607bdd50832681d8de39861e1876