### PR TITLE
feat: add webview routes for codex and daemon

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/web/DesktopWebViewScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/web/DesktopWebViewScreen.kt
@@ -1,0 +1,161 @@
+package com.goofy.goober.shady.feature.web
+
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DesktopWebViewScreen(
+    url: String,
+    title: String,
+    onNavigateUp: () -> Unit,
+) {
+    var webView by remember { mutableStateOf<WebView?>(null) }
+    var progress by remember { mutableStateOf(0) }
+    var errorUrl by remember { mutableStateOf<String?>(null) }
+
+    BackHandler {
+        if (webView?.canGoBack() == true) {
+            webView?.goBack()
+        } else {
+            onNavigateUp()
+        }
+    }
+
+    DisposableEffect(webView) {
+        onDispose { webView?.destroy() }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    TextButton(onClick = onNavigateUp) { Text("Back") }
+                },
+                actions = {
+                    TextButton(onClick = { webView?.reload() }) { Text("Reload") }
+                },
+            )
+        },
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            if (errorUrl != null) {
+                Column(
+                    modifier = Modifier.align(Alignment.Center),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text("Failed to load $errorUrl")
+                    Spacer(Modifier.height(16.dp))
+                    Button(onClick = {
+                        errorUrl = null
+                        webView?.loadUrl(url)
+                    }) { Text("Retry") }
+                }
+            } else {
+                AndroidView(
+                    modifier = Modifier.fillMaxSize(),
+                    factory = { ctx ->
+                        WebView(ctx).apply {
+                            settings.javaScriptEnabled = true
+                            settings.domStorageEnabled = true
+                            settings.useWideViewPort = true
+                            settings.loadWithOverviewMode = true
+                            settings.userAgentString =
+                                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+                            webChromeClient = object : WebChromeClient() {
+                                override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                                    progress = newProgress
+                                }
+                            }
+                            webViewClient = object : WebViewClient() {
+                                override fun shouldOverrideUrlLoading(
+                                    view: WebView?,
+                                    request: WebResourceRequest?,
+                                ): Boolean {
+                                    val target = request?.url ?: return false
+                                    val scheme = target.scheme
+                                    return if (scheme == "http" || scheme == "https") {
+                                        false
+                                    } else {
+                                        try {
+                                            ctx.startActivity(android.content.Intent(android.content.Intent.ACTION_VIEW, target))
+                                        } catch (_: Exception) {
+                                        }
+                                        true
+                                    }
+                                }
+
+                                override fun onPageStarted(view: WebView?, url: String?, favicon: android.graphics.Bitmap?) {
+                                    progress = 0
+                                }
+
+                                override fun onPageFinished(view: WebView?, url: String?) {
+                                    progress = 100
+                                }
+
+                                override fun onReceivedError(
+                                    view: WebView?,
+                                    request: WebResourceRequest?,
+                                    error: WebResourceError?,
+                                ) {
+                                    if (request?.isForMainFrame == true) {
+                                        errorUrl = request.url.toString()
+                                    }
+                                }
+                            }
+                            loadUrl(url)
+                            webView = this
+                        }
+                    },
+                    update = {
+                        if (it.url != url) {
+                            it.loadUrl(url)
+                        }
+                    },
+                )
+            }
+
+            if (progress < 100) {
+                LinearProgressIndicator(
+                    progress = progress / 100f,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.TopCenter),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/goofy/goober/shady/ui/ShadyApp.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/ui/ShadyApp.kt
@@ -31,6 +31,7 @@ import com.goofy.goober.style.LargeCard
 import com.goofy.goober.style.ShadyTheme
 import com.goofy.goober.style.Space
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.goofy.goober.shady.feature.web.DesktopWebViewScreen
 
 @Composable
 fun ShadyApp(modifier: Modifier = Modifier) {
@@ -52,6 +53,31 @@ fun Scaffold(
         .currentBackStackEntryFlow
         .collectAsState(initial = navController.currentBackStackEntry)
 
+    val webScreens = listOf(
+        DestinationScreen(
+            title = "codex",
+            content = {
+                DesktopWebViewScreen(
+                    url = "https://chatgpt.com/codex",
+                    title = "Codex",
+                    onNavigateUp = { navController.navigateUp() }
+                )
+            }
+        ),
+        DestinationScreen(
+            title = "daemon",
+            content = {
+                DesktopWebViewScreen(
+                    url = "https://chatgpt.com/daemon",
+                    title = "Daemon",
+                    onNavigateUp = { navController.navigateUp() }
+                )
+            }
+        ),
+    )
+
+    val allScreens = screens + webScreens
+
     Scaffold(
         modifier = modifier.fillMaxSize(),
         topBar = {
@@ -69,7 +95,7 @@ fun Scaffold(
     ) { padding ->
         Content(
             home = home,
-            screens = screens,
+            screens = allScreens,
             modifier = Modifier.padding(padding),
             navController = navController
         )
@@ -97,14 +123,19 @@ fun Content(
             )
         }
         screens.forEach { screen ->
-            navigation(
-                route = "${screen.title} Home",
-                startDestination = screen.title
-            ) {
-                if (screen is NestedNavScreen) {
-                    screen.nestedGraph(this) {
-                        navController.navigate(it.title)
+            when (screen) {
+                is NestedNavScreen -> {
+                    navigation(
+                        route = "${screen.title} Home",
+                        startDestination = screen.title
+                    ) {
+                        screen.nestedGraph(this) {
+                            navController.navigate(it.title)
+                        }
                     }
+                }
+                is DestinationScreen -> {
+                    composable(screen.title) { screen.content() }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add shared DesktopWebViewScreen
- wire codex and daemon routes into app navigation

## Testing
- `./gradlew --no-daemon assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bcbfb1a083269f402f67377608b8