### PR TITLE
Add portal effect editor with preview

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
@@ -2,9 +2,11 @@ package com.goofy.goober.shady.feature.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -14,6 +16,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.goofy.goober.shady.nav.Routes
+import com.goofy.goober.shady.portal.PortalCanvas
+import com.goofy.goober.shady.portal.PortalState
+import com.goofy.goober.shady.portal.shaderFor
 
 @Composable
 fun HomeScreen(navController: NavController) {
@@ -25,6 +30,8 @@ fun HomeScreen(navController: NavController) {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            PortalCanvas(shader = shaderFor(PortalState.effectId))
+            Spacer(modifier = Modifier.height(24.dp))
             Button(
                 onClick = { navController.navigate(Routes.Codex) },
                 modifier = Modifier

--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectEditorScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectEditorScreen.kt
@@ -1,0 +1,42 @@
+package com.goofy.goober.shady.feature.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.goofy.goober.shady.portal.PortalCanvas
+import com.goofy.goober.shady.portal.shaderFor
+
+@Composable
+fun EffectEditorScreen(
+    effectId: String,
+    onUse: () -> Unit,
+    onBack: () -> Unit
+) {
+    val shader = shaderFor(effectId)
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(effectId) },
+                navigationIcon = {
+                    TextButton(onClick = onBack) { Text("Back") }
+                },
+                actions = {
+                    TextButton(onClick = onUse) { Text("Use") }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            PortalCanvas(shader = shader)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectListScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectListScreen.kt
@@ -13,18 +13,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import com.goofy.goober.shady.animated.AnimatedShadersRoute
-import com.goofy.goober.shady.static.TextureShadersRoute
 
 @Composable
-fun SettingsScreen(navController: NavController) {
+fun EffectListScreen(
+    onOpen: (String) -> Unit,
+    onBack: () -> Unit
+) {
+    val effects = listOf("WARP_TUNNEL", "NOODLE_ZOOM", "GRADIENT_FIELD")
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Settings") },
+                title = { Text("Effects") },
                 navigationIcon = {
-                    TextButton(onClick = { navController.navigateUp() }) { Text("Back") }
+                    TextButton(onClick = onBack) { Text("Back") }
                 }
             )
         }
@@ -35,18 +36,14 @@ fun SettingsScreen(navController: NavController) {
                 .padding(padding),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Button(
-                onClick = { navController.navigate(TextureShadersRoute) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) { Text("Texture Shaders") }
-            Button(
-                onClick = { navController.navigate(AnimatedShadersRoute) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-            ) { Text("Animated Shaders") }
+            effects.forEach { effect ->
+                Button(
+                    onClick = { onOpen(effect) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) { Text(effect) }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
@@ -1,0 +1,48 @@
+package com.goofy.goober.shady.portal
+
+import android.graphics.RuntimeShader
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.dp
+import com.goofy.goober.sketch.SketchWithCache
+
+@Composable
+fun PortalCanvas(
+    shader: RuntimeShader,
+    ringThicknessDp: Float = 6f,
+    modifier: Modifier = Modifier.size(260.dp)
+) {
+    val brush = remember(shader) { ShaderBrush(shader) }
+    SketchWithCache(modifier = modifier) { time ->
+        shader.setFloatUniform("resolution", size.width, size.height)
+        shader.setFloatUniform("time", time)
+        val ringThicknessPx = ringThicknessDp.dp.toPx()
+        val ringRadius = size.minDimension / 2f - ringThicknessPx / 2f
+        val clipRadius = ringRadius - ringThicknessPx / 2f
+        onDrawBehind {
+            val center = Offset(size.width / 2f, size.height / 2f)
+            drawCircle(
+                color = Color.White,
+                radius = ringRadius,
+                center = center,
+                style = Stroke(width = ringThicknessPx)
+            )
+            val path = Path().apply {
+                addOval(Rect(center = center, radius = clipRadius))
+            }
+            clipPath(path) {
+                drawRect(brush)
+            }
+        }
+    }
+}
+

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalState.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalState.kt
@@ -1,0 +1,6 @@
+package com.goofy.goober.shady.portal
+
+object PortalState {
+    var effectId: String = "WARP_TUNNEL"
+    var params: MutableMap<String, Float> = mutableMapOf()
+}

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/ShaderRepo.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/ShaderRepo.kt
@@ -1,0 +1,12 @@
+package com.goofy.goober.shady.portal
+
+import android.graphics.RuntimeShader
+import com.goofy.goober.shaders.GradientShader
+import com.goofy.goober.shaders.NoodleZoomShader
+import com.goofy.goober.shaders.WarpSpeedShader
+
+fun shaderFor(effectId: String): RuntimeShader = when (effectId) {
+    "NOODLE_ZOOM" -> NoodleZoomShader
+    "GRADIENT_FIELD" -> GradientShader
+    else -> WarpSpeedShader
+}

--- a/app/src/main/kotlin/com/goofy/goober/shady/ui/ShadyApp.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/ui/ShadyApp.kt
@@ -6,8 +6,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.goofy.goober.shady.nav.Routes
 import com.goofy.goober.shady.feature.home.HomeScreen
-import com.goofy.goober.shady.feature.settings.SettingsScreen
+import com.goofy.goober.shady.feature.settings.EffectEditorScreen
+import com.goofy.goober.shady.feature.settings.EffectListScreen
 import com.goofy.goober.shady.feature.web.DesktopWebViewScreen
+import com.goofy.goober.shady.portal.PortalState
 import com.goofy.goober.shady.animated.animatedShadersGraph
 import com.goofy.goober.shady.static.textureShadersGraph
 import com.goofy.goober.style.ShadyTheme
@@ -32,7 +34,23 @@ fun ShadyApp() {
                     onNavigateUp = { navController.popBackStack() }
                 )
             }
-            composable(Routes.Settings) { SettingsScreen(navController) }
+            composable(Routes.Settings) {
+                EffectListScreen(
+                    onOpen = { id -> navController.navigate("effect_editor/$id") },
+                    onBack = { navController.navigateUp() }
+                )
+            }
+            composable("effect_editor/{id}") { backStack ->
+                val id = backStack.arguments?.getString("id")!!
+                EffectEditorScreen(
+                    effectId = id,
+                    onUse = {
+                        PortalState.effectId = id
+                        navController.navigateUp()
+                    },
+                    onBack = { navController.navigateUp() }
+                )
+            }
             textureShadersGraph { navController.navigate(it.title) }
             animatedShadersGraph { navController.navigate(it.title) }
         }


### PR DESCRIPTION
## Summary
- Add PortalState and PortalCanvas for circular shader previews
- Introduce settings EffectList and EffectEditor screens to pick shaders
- Wire navigation and home screen to show chosen effect

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ae1a3f8832695d883cf4f3cd45b