### PR TITLE
Add dynamic portal effect controls with live shader preview

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -18,6 +19,7 @@ import androidx.navigation.NavController
 import com.goofy.goober.shady.nav.Routes
 import com.goofy.goober.shady.portal.PortalCanvas
 import com.goofy.goober.shady.portal.PortalState
+import com.goofy.goober.shady.portal.Effects
 import com.goofy.goober.shady.portal.shaderFor
 
 @Composable
@@ -30,7 +32,13 @@ fun HomeScreen(navController: NavController) {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            PortalCanvas(shader = shaderFor(PortalState.effectId))
+            val spec = remember(PortalState.effectId) { Effects.specFor(PortalState.effectId) }
+            val params = PortalState.paramsByEffect[PortalState.effectId]
+                ?: spec.params.associate { it.key to it.default }.toMutableMap()
+            PortalCanvas(
+                shader = shaderFor(PortalState.effectId),
+                onFrame = { shader, size, time -> spec.apply(shader, params, size, time) }
+            )
             Spacer(modifier = Modifier.height(24.dp))
             Button(
                 onClick = { navController.navigate(Routes.Codex) },

--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectEditorScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectEditorScreen.kt
@@ -1,24 +1,37 @@
 package com.goofy.goober.shady.feature.settings
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.goofy.goober.shady.portal.Effects
 import com.goofy.goober.shady.portal.PortalCanvas
+import com.goofy.goober.shady.portal.PortalState
 import com.goofy.goober.shady.portal.shaderFor
 
 @Composable
 fun EffectEditorScreen(
     effectId: String,
     onUse: () -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
 ) {
-    val shader = shaderFor(effectId)
+    val spec = remember(effectId) { Effects.specFor(effectId) }
+    val local = remember(spec) {
+        mutableStateMapOf<String, Float>().apply {
+            spec.params.forEach { put(it.key, it.default) }
+            PortalState.paramsByEffect[effectId]?.let { putAll(it) }
+        }
+    }
+    val shader = remember(effectId) { shaderFor(effectId) }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -27,16 +40,35 @@ fun EffectEditorScreen(
                     TextButton(onClick = onBack) { Text("Back") }
                 },
                 actions = {
-                    TextButton(onClick = onUse) { Text("Use") }
+                    TextButton(onClick = {
+                        PortalState.effectId = effectId
+                        PortalState.paramsByEffect[effectId] = local.toMutableMap()
+                        onUse()
+                    }) { Text("Use") }
                 }
             )
         }
     ) { padding ->
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            PortalCanvas(shader = shader)
+            PortalCanvas(
+                shader = shader,
+                onFrame = { s, size, time -> spec.apply(s, local, size, time) }
+            )
+            spec.params.forEach { param ->
+                val value = local[param.key] ?: param.default
+                Text("${param.label}: ${String.format("%.2f", value)}")
+                Slider(
+                    value = value,
+                    onValueChange = { local[param.key] = it },
+                    valueRange = param.min..param.max
+                )
+            }
         }
     }
 }
+

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/EffectSpecs.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/EffectSpecs.kt
@@ -1,0 +1,55 @@
+package com.goofy.goober.shady.portal
+
+import android.graphics.RuntimeShader
+import androidx.compose.ui.geometry.Size
+
+data class Param(val key: String, val label: String, val min: Float, val max: Float, val default: Float)
+
+data class EffectSpec(
+    val id: String,
+    val params: List<Param>,
+    val apply: (shader: RuntimeShader, params: Map<String, Float>, sizePx: Size, timeSec: Float) -> Unit
+)
+
+object Effects {
+    val WARP_TUNNEL = EffectSpec(
+        id = "WARP_TUNNEL",
+        params = listOf(
+            Param("speed", "Speed", 0f, 2f, 1.0f)
+        ),
+        apply = { shader, p, size, t ->
+            shader.setFloatUniform("resolution", size.width, size.height)
+            shader.setFloatUniform("time", t * (p["speed"] ?: 1f))
+        }
+    )
+
+    val NOODLE_ZOOM = EffectSpec(
+        id = "NOODLE_ZOOM",
+        params = listOf(
+            Param("speed", "Speed", 0f, 2f, 1.0f)
+        ),
+        apply = { shader, p, size, t ->
+            shader.setFloatUniform("resolution", size.width, size.height)
+            shader.setFloatUniform("time", t * (p["speed"] ?: 1f))
+        }
+    )
+
+    val GRADIENT_FIELD = EffectSpec(
+        id = "GRADIENT_FIELD",
+        params = listOf(
+            Param("speed", "Speed", 0f, 2f, 1.0f)
+        ),
+        apply = { shader, p, size, t ->
+            shader.setFloatUniform("resolution", size.width, size.height)
+            shader.setFloatUniform("time", t * (p["speed"] ?: 1f))
+        }
+    )
+
+    fun specFor(id: String) = when (id) {
+        "WARP_TUNNEL" -> WARP_TUNNEL
+        "NOODLE_ZOOM" -> NOODLE_ZOOM
+        "GRADIENT_FIELD" -> GRADIENT_FIELD
+        else -> GRADIENT_FIELD
+    }
+}
+

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/FrameTime.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/FrameTime.kt
@@ -1,0 +1,31 @@
+package com.goofy.goober.shady.portal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.animation.core.withFrameNanos
+
+@Composable
+fun rememberFrameSeconds(paused: Boolean = false): Float {
+    var time by remember { mutableStateOf(0f) }
+    LaunchedEffect(paused) {
+        var lastNanos = 0L
+        while (true) {
+            withFrameNanos { nanos ->
+                if (lastNanos == 0L) {
+                    lastNanos = nanos
+                }
+                if (!paused) {
+                    val delta = (nanos - lastNanos) / 1_000_000_000f
+                    time += delta
+                }
+                lastNanos = nanos
+            }
+        }
+    }
+    return time
+}
+

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
@@ -1,48 +1,52 @@
 package com.goofy.goober.shady.portal
 
 import android.graphics.RuntimeShader
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipPath
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.drawscope.drawWithCache
 import androidx.compose.ui.unit.dp
-import com.goofy.goober.sketch.SketchWithCache
 
 @Composable
 fun PortalCanvas(
     shader: RuntimeShader,
     ringThicknessDp: Float = 6f,
-    modifier: Modifier = Modifier.size(260.dp)
+    modifier: Modifier = Modifier.size(260.dp),
+    onFrame: ((shader: RuntimeShader, sizePx: Size, timeSec: Float) -> Unit)? = null,
 ) {
     val brush = remember(shader) { ShaderBrush(shader) }
-    SketchWithCache(modifier = modifier) { time ->
-        shader.setFloatUniform("resolution", size.width, size.height)
-        shader.setFloatUniform("time", time)
-        val ringThicknessPx = ringThicknessDp.dp.toPx()
-        val ringRadius = size.minDimension / 2f - ringThicknessPx / 2f
-        val clipRadius = ringRadius - ringThicknessPx / 2f
-        onDrawBehind {
+    val time = rememberFrameSeconds()
+    val currentTime by rememberUpdatedState(time)
+    val currentOnFrame by rememberUpdatedState(onFrame)
+    Canvas(
+        modifier = modifier.drawWithCache {
+            val ringThicknessPx = ringThicknessDp.dp.toPx()
+            val ringRadius = size.minDimension / 2f - ringThicknessPx / 2f
+            val clipRadius = ringRadius - ringThicknessPx / 2f
             val center = Offset(size.width / 2f, size.height / 2f)
-            drawCircle(
-                color = Color.White,
-                radius = ringRadius,
-                center = center,
-                style = Stroke(width = ringThicknessPx)
-            )
-            val path = Path().apply {
-                addOval(Rect(center = center, radius = clipRadius))
-            }
-            clipPath(path) {
-                drawRect(brush)
+            val path = Path().apply { addOval(Rect(center = center, radius = clipRadius)) }
+            onDrawBehind {
+                currentOnFrame?.invoke(shader, size, currentTime)
+                drawCircle(
+                    color = Color.White,
+                    radius = ringRadius,
+                    center = center,
+                    style = Stroke(width = ringThicknessPx)
+                )
+                clipPath(path) { drawRect(brush) }
             }
         }
-    }
+    )
 }
 

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalState.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalState.kt
@@ -2,5 +2,5 @@ package com.goofy.goober.shady.portal
 
 object PortalState {
     var effectId: String = "WARP_TUNNEL"
-    var params: MutableMap<String, Float> = mutableMapOf()
+    val paramsByEffect: MutableMap<String, MutableMap<String, Float>> = mutableMapOf()
 }

--- a/app/src/main/kotlin/com/goofy/goober/shady/ui/ShadyApp.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/ui/ShadyApp.kt
@@ -9,7 +9,6 @@ import com.goofy.goober.shady.feature.home.HomeScreen
 import com.goofy.goober.shady.feature.settings.EffectEditorScreen
 import com.goofy.goober.shady.feature.settings.EffectListScreen
 import com.goofy.goober.shady.feature.web.DesktopWebViewScreen
-import com.goofy.goober.shady.portal.PortalState
 import com.goofy.goober.shady.animated.animatedShadersGraph
 import com.goofy.goober.shady.static.textureShadersGraph
 import com.goofy.goober.style.ShadyTheme
@@ -44,10 +43,7 @@ fun ShadyApp() {
                 val id = backStack.arguments?.getString("id")!!
                 EffectEditorScreen(
                     effectId = id,
-                    onUse = {
-                        PortalState.effectId = id
-                        navController.navigateUp()
-                    },
+                    onUse = { navController.navigateUp() },
                     onBack = { navController.navigateUp() }
                 )
             }


### PR DESCRIPTION
## Summary
- track portal parameters per effect and restore demo shader sources
- simplify effect specs to existing uniforms and use drawWithCache canvas
- persist tuned parameters and apply them on editor and home screens

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99e6347c48326a8e3d30d33f832ea