### PR TITLE
Fix Compose runtime imports for portal

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/FrameTime.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/FrameTime.kt
@@ -2,15 +2,15 @@ package com.goofy.goober.shady.portal
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.animation.core.withFrameNanos
+import androidx.compose.runtime.withFrameNanos
 
 @Composable
 fun rememberFrameSeconds(paused: Boolean = false): Float {
-    var time by remember { mutableStateOf(0f) }
+    var time by remember { mutableFloatStateOf(0f) }
     LaunchedEffect(paused) {
         var lastNanos = 0L
         while (true) {

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
@@ -6,16 +6,21 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.ShaderBrush
-import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.Stroke
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipPath
-import androidx.compose.ui.graphics.drawscope.drawWithCache
+import androidx.compose.ui.graphics.drawscope.drawCircle
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.drawscope.drawRect
 import androidx.compose.ui.unit.dp
 
 @Composable


### PR DESCRIPTION
## Summary
- fix frame time state with runtime `withFrameNanos` and `mutableFloatStateOf`
- update PortalCanvas imports and delegate to use runtime `getValue` and correct `drawWithCache`

## Testing
- `./gradlew clean assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a56f47788326ab885296a8eebd39