### PR TITLE
Refactor portal rendering

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -32,12 +31,12 @@ fun HomeScreen(navController: NavController) {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            val spec = remember(PortalState.effectId) { Effects.specFor(PortalState.effectId) }
-            val params = PortalState.paramsByEffect[PortalState.effectId]
-                ?: spec.params.associate { it.key to it.default }.toMutableMap()
+            val effectId = PortalState.effectId
+            val spec = Effects.specFor(effectId)
+            val params = PortalState.paramsByEffect[effectId] ?: spec.defaults()
             PortalCanvas(
-                shader = shaderFor(PortalState.effectId),
-                onFrame = { shader, size, time -> spec.apply(shader, params, size, time) }
+                shader = shaderFor(effectId),
+                onFrame = { s, size, t -> spec.apply(s, params, size, t) }
             )
             Spacer(modifier = Modifier.height(24.dp))
             Button(

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/EffectSpecs.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/EffectSpecs.kt
@@ -9,7 +9,10 @@ data class EffectSpec(
     val id: String,
     val params: List<Param>,
     val apply: (shader: RuntimeShader, params: Map<String, Float>, sizePx: Size, timeSec: Float) -> Unit
-)
+) {
+    fun defaults(): MutableMap<String, Float> =
+        params.associate { it.key to it.default }.toMutableMap()
+}
 
 object Effects {
     val WARP_TUNNEL = EffectSpec(
@@ -17,9 +20,9 @@ object Effects {
         params = listOf(
             Param("speed", "Speed", 0f, 2f, 1.0f)
         ),
-        apply = { shader, p, size, t ->
+        apply = { shader, params, size, timeSec ->
             shader.setFloatUniform("resolution", size.width, size.height)
-            shader.setFloatUniform("time", t * (p["speed"] ?: 1f))
+            shader.setFloatUniform("time", timeSec * (params["speed"] ?: 1f))
         }
     )
 
@@ -28,9 +31,9 @@ object Effects {
         params = listOf(
             Param("speed", "Speed", 0f, 2f, 1.0f)
         ),
-        apply = { shader, p, size, t ->
+        apply = { shader, params, size, timeSec ->
             shader.setFloatUniform("resolution", size.width, size.height)
-            shader.setFloatUniform("time", t * (p["speed"] ?: 1f))
+            shader.setFloatUniform("time", timeSec * (params["speed"] ?: 1f))
         }
     )
 
@@ -39,9 +42,9 @@ object Effects {
         params = listOf(
             Param("speed", "Speed", 0f, 2f, 1.0f)
         ),
-        apply = { shader, p, size, t ->
+        apply = { shader, params, size, timeSec ->
             shader.setFloatUniform("resolution", size.width, size.height)
-            shader.setFloatUniform("time", t * (p["speed"] ?: 1f))
+            shader.setFloatUniform("time", timeSec * (params["speed"] ?: 1f))
         }
     )
 

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/FrameTime.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/FrameTime.kt
@@ -2,10 +2,10 @@ package com.goofy.goober.shady.portal
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
 
 @Composable

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
@@ -1,8 +1,5 @@
 package com.goofy.goober.shady.portal
 
-import android.graphics.RuntimeShader
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -15,43 +12,56 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.ShaderBrush
-import androidx.compose.ui.graphics.Stroke
-import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipPath
-import androidx.compose.ui.graphics.drawscope.drawCircle
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.drawscope.drawRect
+import androidx.compose.ui.graphics.drawscope.drawCircle
 import androidx.compose.ui.unit.dp
+import android.graphics.RuntimeShader
 
 @Composable
 fun PortalCanvas(
+    modifier: Modifier = Modifier,
     shader: RuntimeShader,
     ringThicknessDp: Float = 6f,
-    modifier: Modifier = Modifier.size(260.dp),
     onFrame: ((shader: RuntimeShader, sizePx: Size, timeSec: Float) -> Unit)? = null,
+    timeSec: Float = rememberFrameSeconds()
 ) {
+    // Remember brush once per shader instance
     val brush = remember(shader) { ShaderBrush(shader) }
-    val time = rememberFrameSeconds()
-    val currentTime by rememberUpdatedState(time)
+    // Keep a current callback reference
     val currentOnFrame by rememberUpdatedState(onFrame)
-    Canvas(
+
+    androidx.compose.foundation.layout.Box(
         modifier = modifier.drawWithCache {
+            // cache setup
             val ringThicknessPx = ringThicknessDp.dp.toPx()
             val ringRadius = size.minDimension / 2f - ringThicknessPx / 2f
             val clipRadius = ringRadius - ringThicknessPx / 2f
             val center = Offset(size.width / 2f, size.height / 2f)
-            val path = Path().apply { addOval(Rect(center = center, radius = clipRadius)) }
-            onDrawBehind {
-                currentOnFrame?.invoke(shader, size, currentTime)
+
+            // prebuild clip path
+            val clipPath = Path().apply {
+                addOval(Rect(center = center, radius = clipRadius))
+            }
+
+            onDrawWithContent {
+                // per-frame uniform updates before draw
+                currentOnFrame?.invoke(shader, size, timeSec)
+
+                // ring stroke
                 drawCircle(
                     color = Color.White,
                     radius = ringRadius,
                     center = center,
                     style = Stroke(width = ringThicknessPx)
                 )
-                clipPath(path) { drawRect(brush) }
+
+                // shader fill clipped to circle
+                clipPath(clipPath) {
+                    drawRect(brush = brush)
+                }
             }
         }
     )
 }
-


### PR DESCRIPTION
## Summary
- draw portal effects using `drawWithCache` instead of `Canvas`
- simplify effect specs and per-effect parameters
- wire uniform updates through `onFrame`

## Testing
- `./gradlew clean assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a951dc048326a306e2f614846640