### PR TITLE
Unify shader pipeline (Compose RuntimeShader) + lean PortalCanvas + single timing helper

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
@@ -19,7 +19,6 @@ import com.goofy.goober.shady.nav.Routes
 import com.goofy.goober.shady.portal.PortalCanvas
 import com.goofy.goober.shady.portal.PortalState
 import com.goofy.goober.shady.portal.Effects
-import com.goofy.goober.shady.portal.shaderFor
 
 @Composable
 fun HomeScreen(navController: NavController) {
@@ -35,8 +34,8 @@ fun HomeScreen(navController: NavController) {
             val spec = Effects.specFor(effectId)
             val params = PortalState.paramsByEffect[effectId] ?: spec.defaults()
             PortalCanvas(
-                shader = shaderFor(effectId),
-                onFrame = { s, size, t -> spec.apply(s, params, size, t) }
+                spec = spec,
+                params = params
             )
             Spacer(modifier = Modifier.height(24.dp))
             Button(

--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectEditorScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectEditorScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Modifier
 import com.goofy.goober.shady.portal.Effects
 import com.goofy.goober.shady.portal.PortalCanvas
 import com.goofy.goober.shady.portal.PortalState
-import com.goofy.goober.shady.portal.shaderFor
 
 @Composable
 fun EffectEditorScreen(
@@ -30,7 +29,6 @@ fun EffectEditorScreen(
             putAll(PortalState.paramsByEffect[effectId] ?: spec.defaults())
         }
     }
-    val shader = remember(effectId) { shaderFor(effectId) }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -55,8 +53,8 @@ fun EffectEditorScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             PortalCanvas(
-                shader = shader,
-                onFrame = { s, size, t -> spec.apply(s, params, size, t) }
+                spec = spec,
+                params = params
             )
             spec.params.forEach { param ->
                 val value = params[param.key] ?: param.default

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/EffectSpecs.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/EffectSpecs.kt
@@ -1,14 +1,13 @@
 package com.goofy.goober.shady.portal
 
-import android.graphics.RuntimeShader
-import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.RuntimeShader
 
 data class Param(val key: String, val label: String, val min: Float, val max: Float, val default: Float)
 
 data class EffectSpec(
-    val id: String,
+    val runtimeId: String,
     val params: List<Param>,
-    val apply: (shader: RuntimeShader, params: Map<String, Float>, sizePx: Size, timeSec: Float) -> Unit
+    val apply: (RuntimeShader, Map<String, Float>) -> Unit
 ) {
     fun defaults(): MutableMap<String, Float> =
         params.associate { it.key to it.default }.toMutableMap()
@@ -16,36 +15,27 @@ data class EffectSpec(
 
 object Effects {
     val WARP_TUNNEL = EffectSpec(
-        id = "WARP_TUNNEL",
+        runtimeId = "WARP_TUNNEL",
         params = listOf(
             Param("speed", "Speed", 0f, 2f, 1.0f)
         ),
-        apply = { shader, params, size, timeSec ->
-            shader.setFloatUniform("resolution", size.width, size.height)
-            shader.setFloatUniform("time", timeSec * (params["speed"] ?: 1f))
-        }
+        apply = { _, _ -> }
     )
 
     val NOODLE_ZOOM = EffectSpec(
-        id = "NOODLE_ZOOM",
+        runtimeId = "NOODLE_ZOOM",
         params = listOf(
             Param("speed", "Speed", 0f, 2f, 1.0f)
         ),
-        apply = { shader, params, size, timeSec ->
-            shader.setFloatUniform("resolution", size.width, size.height)
-            shader.setFloatUniform("time", timeSec * (params["speed"] ?: 1f))
-        }
+        apply = { _, _ -> }
     )
 
     val GRADIENT_FIELD = EffectSpec(
-        id = "GRADIENT_FIELD",
+        runtimeId = "GRADIENT_FIELD",
         params = listOf(
             Param("speed", "Speed", 0f, 2f, 1.0f)
         ),
-        apply = { shader, params, size, timeSec ->
-            shader.setFloatUniform("resolution", size.width, size.height)
-            shader.setFloatUniform("time", timeSec * (params["speed"] ?: 1f))
-        }
+        apply = { _, _ -> }
     )
 
     fun specFor(id: String) = when (id) {
@@ -55,4 +45,3 @@ object Effects {
         else -> GRADIENT_FIELD
     }
 }
-

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/FrameTime.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/FrameTime.kt
@@ -1,31 +1,19 @@
 package com.goofy.goober.shady.portal
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.withFrameNanos
 
 @Composable
-fun rememberFrameSeconds(paused: Boolean = false): Float {
-    var time by remember { mutableFloatStateOf(0f) }
-    LaunchedEffect(paused) {
-        var lastNanos = 0L
+fun rememberFrameSeconds(): State<Float> {
+    return produceState(0f) {
+        var start = 0L
         while (true) {
-            withFrameNanos { nanos ->
-                if (lastNanos == 0L) {
-                    lastNanos = nanos
-                }
-                if (!paused) {
-                    val delta = (nanos - lastNanos) / 1_000_000_000f
-                    time += delta
-                }
-                lastNanos = nanos
+            withFrameNanos { now ->
+                if (start == 0L) start = now
+                value = (now - start) / 1_000_000_000f
             }
         }
     }
-    return time
 }
-

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
@@ -1,9 +1,8 @@
 package com.goofy.goober.shady.portal
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
@@ -12,44 +11,35 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.ShaderBrush
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.clipPath
-import androidx.compose.ui.graphics.drawscope.drawRect
-import androidx.compose.ui.graphics.drawscope.drawCircle
+import androidx.compose.ui.graphics.drawscope.*
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import android.graphics.RuntimeShader
 
 @Composable
 fun PortalCanvas(
+    spec: EffectSpec,
+    params: Map<String, Float>,
     modifier: Modifier = Modifier,
-    shader: RuntimeShader,
-    ringThicknessDp: Float = 6f,
-    onFrame: ((shader: RuntimeShader, sizePx: Size, timeSec: Float) -> Unit)? = null,
-    timeSec: Float = rememberFrameSeconds()
+    ringThicknessDp: Dp = 8.dp
 ) {
-    // Remember brush once per shader instance
+    val shader = remember(spec.runtimeId) { ShaderRepo.get(spec.runtimeId) }
     val brush = remember(shader) { ShaderBrush(shader) }
-    // Keep a current callback reference
-    val currentOnFrame by rememberUpdatedState(onFrame)
+    val t by rememberFrameSeconds()
 
     androidx.compose.foundation.layout.Box(
         modifier = modifier.drawWithCache {
-            // cache setup
-            val ringThicknessPx = ringThicknessDp.dp.toPx()
+            val ringThicknessPx = ringThicknessDp.toPx()
             val ringRadius = size.minDimension / 2f - ringThicknessPx / 2f
             val clipRadius = ringRadius - ringThicknessPx / 2f
             val center = Offset(size.width / 2f, size.height / 2f)
-
-            // prebuild clip path
-            val clipPath = Path().apply {
-                addOval(Rect(center = center, radius = clipRadius))
-            }
+            val path = Path().apply { addOval(Rect(center = center, radius = clipRadius)) }
 
             onDrawWithContent {
-                // per-frame uniform updates before draw
-                currentOnFrame?.invoke(shader, size, timeSec)
+                val speed = params["speed"] ?: 1f
+                shader.setFloatUniform("time", t * speed)
+                shader.setFloatUniform("resolution", size.width, size.height)
+                spec.apply(shader, params)
 
-                // ring stroke
                 drawCircle(
                     color = Color.White,
                     radius = ringRadius,
@@ -57,8 +47,7 @@ fun PortalCanvas(
                     style = Stroke(width = ringThicknessPx)
                 )
 
-                // shader fill clipped to circle
-                clipPath(clipPath) {
+                clipPath(path) {
                     drawRect(brush = brush)
                 }
             }

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/ShaderRepo.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/ShaderRepo.kt
@@ -1,12 +1,14 @@
 package com.goofy.goober.shady.portal
 
-import android.graphics.RuntimeShader
+import androidx.compose.ui.graphics.RuntimeShader
 import com.goofy.goober.shaders.GradientShader
 import com.goofy.goober.shaders.NoodleZoomShader
 import com.goofy.goober.shaders.WarpSpeedShader
 
-fun shaderFor(effectId: String): RuntimeShader = when (effectId) {
-    "NOODLE_ZOOM" -> NoodleZoomShader
-    "GRADIENT_FIELD" -> GradientShader
-    else -> WarpSpeedShader
+object ShaderRepo {
+    fun get(id: String): RuntimeShader = when (id) {
+        "NOODLE_ZOOM" -> NoodleZoomShader
+        "GRADIENT_FIELD" -> GradientShader
+        else -> WarpSpeedShader
+    }
 }

--- a/app/src/main/kotlin/com/goofy/goober/shady/static/ShaderContent.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/static/ShaderContent.kt
@@ -1,7 +1,7 @@
 package com.goofy.goober.shady.static
 
 import android.content.res.Configuration
-import android.graphics.RenderEffect
+import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize

--- a/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
+++ b/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
@@ -1,6 +1,6 @@
 package com.goofy.goober.shaders
 
-import android.graphics.RuntimeShader
+import androidx.compose.ui.graphics.RuntimeShader
 
 /**
  * Shadertoy's default shader

--- a/shaders/src/main/kotlin/com/goofy/goober/shaders/Texture.kt
+++ b/shaders/src/main/kotlin/com/goofy/goober/shaders/Texture.kt
@@ -1,6 +1,6 @@
 package com.goofy.goober.shaders
 
-import android.graphics.RuntimeShader
+import androidx.compose.ui.graphics.RuntimeShader
 import org.intellij.lang.annotations.Language
 
 /**


### PR DESCRIPTION
## Summary
- refactor `PortalCanvas` to reuse a single `ShaderBrush` and update uniforms via Compose's `RuntimeShader`
- consolidate timing with `rememberFrameSeconds` and streamline `EffectSpec`/`ShaderRepo`
- update editor and home screens to the new shader pipeline and drop `android.graphics` imports

## Testing
- `rg -n "import android\.graphics\." app/ shaders/`
- `./gradlew --no-daemon clean assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c05c3e748326b2ca8f0304605caf