### PR TITLE
Replace home screen buttons with monospaced title/subtitle

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
@@ -4,18 +4,19 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.height
-import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
-import com.goofy.goober.shady.nav.Routes
 import com.goofy.goober.shady.portal.PortalCanvas
 import com.goofy.goober.shady.portal.PortalState
 import com.goofy.goober.shady.portal.shaderFor
@@ -30,26 +31,25 @@ fun HomeScreen(navController: NavController) {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            Text(
+                text = "ULTIMA",
+                color = MaterialTheme.colorScheme.primary,
+                fontFamily = FontFamily.Monospace,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 36.sp,
+                letterSpacing = 2.sp,
+            )
+            Spacer(modifier = Modifier.height(32.dp))
             PortalCanvas(shader = shaderFor(PortalState.effectId))
-            Spacer(modifier = Modifier.height(24.dp))
-            Button(
-                onClick = { navController.navigate(Routes.Codex) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) { Text("Codex") }
-            Button(
-                onClick = { navController.navigate(Routes.Daemon) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-            ) { Text("Daemon") }
-            Button(
-                onClick = { navController.navigate(Routes.Settings) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) { Text("Settings") }
+            Spacer(modifier = Modifier.height(20.dp))
+            Text(
+                text = "codex · daemon · settings",
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                fontFamily = FontFamily.Monospace,
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp,
+                letterSpacing = 1.5.sp,
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace Codex, Daemon and Settings buttons with centered monospaced title and subtitle
- Keep portal view and spacing intact

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68babfe54ad4832695c581ea8cd4bcca