### PR TITLE
Restore navigation links on home screen

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
@@ -1,7 +1,12 @@
 package com.goofy.goober.shady.feature.home
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -10,13 +15,18 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.goofy.goober.shady.nav.Routes
 import com.goofy.goober.shady.portal.PortalCanvas
 import com.goofy.goober.shady.portal.PortalState
 import com.goofy.goober.shady.portal.shaderFor
@@ -42,14 +52,57 @@ fun HomeScreen(navController: NavController) {
             Spacer(modifier = Modifier.height(32.dp))
             PortalCanvas(shader = shaderFor(PortalState.effectId))
             Spacer(modifier = Modifier.height(20.dp))
-            Text(
-                text = "codex · daemon · settings",
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
-                fontFamily = FontFamily.Monospace,
-                fontWeight = FontWeight.Medium,
-                fontSize = 16.sp,
-                letterSpacing = 1.5.sp,
-            )
+            Row {
+                NavText(label = "codex") {
+                    navController.navigate(Routes.Codex)
+                }
+                Text(
+                    text = " · ",
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 16.sp,
+                    letterSpacing = 1.5.sp,
+                )
+                NavText(label = "daemon") {
+                    navController.navigate(Routes.Daemon)
+                }
+                Text(
+                    text = " · ",
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 16.sp,
+                    letterSpacing = 1.5.sp,
+                )
+                NavText(label = "settings") {
+                    navController.navigate(Routes.Settings)
+                }
+            }
         }
     }
+}
+
+@Composable
+private fun NavText(label: String, onClick: () -> Unit) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
+    val targetAlpha = if (pressed) 0.4f else 0.7f
+    val alpha by animateFloatAsState(targetValue = targetAlpha, label = "navAlpha")
+
+    Text(
+        text = label,
+        modifier = Modifier
+            .semantics { contentDescription = label }
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            ),
+        color = MaterialTheme.colorScheme.onBackground.copy(alpha = alpha),
+        fontFamily = FontFamily.Monospace,
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        letterSpacing = 1.5.sp,
+    )
 }


### PR DESCRIPTION
## Summary
- Restore Codex, Daemon, and Settings navigation using clickable monospace links
- Add simple pressed alpha feedback and semantics to home screen links

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68badc0b22bc83268315b30b5ff73d61