### PR TITLE
Add speed uniform with slider

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/home/HomeScreen.kt
@@ -33,6 +33,7 @@ import com.goofy.goober.shady.portal.shaderFor
 
 @Composable
 fun HomeScreen(navController: NavController) {
+    val params = PortalState.params
     Scaffold { padding ->
         Column(
             modifier = Modifier
@@ -50,7 +51,7 @@ fun HomeScreen(navController: NavController) {
                 letterSpacing = 2.sp,
             )
             Spacer(modifier = Modifier.height(32.dp))
-            PortalCanvas(shader = shaderFor(PortalState.effectId))
+            PortalCanvas(shader = shaderFor(PortalState.effectId), params = params)
             Spacer(modifier = Modifier.height(20.dp))
             Row {
                 NavText(label = "codex") {

--- a/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectEditorScreen.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/feature/settings/EffectEditorScreen.kt
@@ -1,15 +1,25 @@
 package com.goofy.goober.shady.feature.settings
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
 import com.goofy.goober.shady.portal.PortalCanvas
+import com.goofy.goober.shady.portal.PortalState
 import com.goofy.goober.shady.portal.shaderFor
 
 @Composable
@@ -19,6 +29,8 @@ fun EffectEditorScreen(
     onBack: () -> Unit
 ) {
     val shader = shaderFor(effectId)
+    val params = PortalState.params
+    var tempSpeed by remember { mutableStateOf(params.speed) }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -33,10 +45,28 @@ fun EffectEditorScreen(
         }
     ) { padding ->
         Box(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
             contentAlignment = Alignment.Center
         ) {
-            PortalCanvas(shader = shader)
+            PortalCanvas(shader = shader, params = params)
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("speed", fontFamily = FontFamily.Monospace)
+                Slider(
+                    value = tempSpeed,
+                    onValueChange = { tempSpeed = it },
+                    valueRange = 0f..1f,
+                    onValueChangeFinished = {
+                        PortalState.params = PortalState.params.copy(speed = tempSpeed)
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
@@ -18,6 +18,7 @@ import com.goofy.goober.sketch.SketchWithCache
 @Composable
 fun PortalCanvas(
     shader: RuntimeShader,
+    params: EffectParams,
     ringThicknessDp: Float = 6f,
     modifier: Modifier = Modifier.size(260.dp)
 ) {
@@ -25,6 +26,7 @@ fun PortalCanvas(
     SketchWithCache(modifier = modifier) { time ->
         shader.setFloatUniform("resolution", size.width, size.height)
         shader.setFloatUniform("time", time)
+        shader.setFloatUniform("uSpeed", params.speed)
         val ringThicknessPx = ringThicknessDp.dp.toPx()
         val ringRadius = size.minDimension / 2f - ringThicknessPx / 2f
         val clipRadius = ringRadius - ringThicknessPx / 2f

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalState.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalState.kt
@@ -1,6 +1,12 @@
 package com.goofy.goober.shady.portal
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+data class EffectParams(val speed: Float = 0.5f)
+
 object PortalState {
     var effectId: String = "WARP_TUNNEL"
-    var params: MutableMap<String, Float> = mutableMapOf()
+    var params by mutableStateOf(EffectParams())
 }

--- a/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
+++ b/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
@@ -63,15 +63,18 @@ val WarpSpeedShader = RuntimeShader(
         //----------------------------------------------------------------------------------------
         uniform float2 resolution;      // Viewport resolution (pixels)
         uniform float  time;            // Shader playback time (s)
+        uniform float uSpeed;  // 0..1
 
         vec4 main( in float2 fragCoord )
         {
             float s = 0.0, v = 0.0;
             vec2 uv = (fragCoord / resolution.xy) * 2.0 - 1.;
-            float time = (time-2.0)*58.0;
+            float t = (time-2.0)*58.0;
+            float speedScale = mix(0.1, 2.0, clamp(uSpeed, 0.0, 1.0));
+            t *= speedScale;
             vec3 col = vec3(0);
-            vec3 init = vec3(sin(time * .0032)*.3, .35 - cos(time * .005)*.3, time * 0.002);
-            for (int r = 0; r < 100; r++) 
+            vec3 init = vec3(sin(t * .0032)*.3, .35 - cos(t * .005)*.3, t * 0.002);
+            for (int r = 0; r < 100; r++)
             {
                 vec3 p = init + s * vec3(uv, 0.05);
                 p.z = fract(p.z);


### PR DESCRIPTION
## Summary
- Add `EffectParams` with mutable speed and expose through `PortalState`
- Wire `uSpeed` uniform into shader and canvas
- Add Settings editor slider committing speed on pointer-up

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bafbaf6ab48326b4f7cc3ca42222f7