### PR TITLE
Add uSpeed scaling to Gradient and DoodleZoom shaders

### DIFF
--- a/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
+++ b/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
@@ -9,14 +9,17 @@ val GradientShader = RuntimeShader(
     """
         uniform float2 resolution;
         uniform float time;
-        
+        uniform float uSpeed;   // 0..1
+
         vec4 main(vec2 fragCoord) {
             // Normalized pixel coordinates (from 0 to 1)
             vec2 uv = fragCoord/resolution.xy;
-    
+
             // Time varying pixel color
-            vec3 col = 0.8 + 0.2 * cos(time*2.0+uv.xxx*2.0+vec3(1,2,4));
-    
+            float speedScale = mix(0.1, 2.0, clamp(uSpeed, 0.0, 1.0));
+            float t2 = time * speedScale; // scale time
+            vec3 col = 0.8 + 0.2 * cos(t2*2.0+uv.xxx*2.0+vec3(1,2,4));
+
             // Output to screen
             return vec4(col,1.0);
         }
@@ -30,16 +33,19 @@ val NoodleZoomShader = RuntimeShader(
     """
         uniform float2 resolution;
         uniform float time;
+        uniform float uSpeed;   // 0..1
+        float speedScale = mix(0.1, 2.0, clamp(uSpeed, 0.0, 1.0));
+        float t2 = time * speedScale; // scale time
 
         // Source: @notargs https://twitter.com/notargs/status/1250468645030858753
         float f(vec3 p) {
-            p.z -= time * 10.;
+            p.z -= t2 * 10.;
             float a = p.z * .1;
             p.xy *= mat2(cos(a), sin(a), -sin(a), cos(a));
             return .1 - length(cos(p.xy) + sin(p.yz));
         }
-        
-        half4 main(vec2 fragcoord) { 
+
+        half4 main(vec2 fragcoord) {
             vec3 d = .5 - fragcoord.xy1 / resolution.y;
             vec3 p=vec3(0);
             for (int i = 0; i < 32; i++) {


### PR DESCRIPTION
## Summary
- Apply uSpeed uniform to Gradient and DoodleZoom portal shaders with 0.1x–2x speed scaling
- Leave Warp Tunnel behavior intact and confirm Kotlin writes uSpeed uniform

## Testing
- `./gradlew :shaders:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb06d20b688326ba7744d60c0e8886