### PR TITLE
shader: add uSpeed uniform and apply local speedScale+t2 inside Gradient and DoodleZoom (safe, no globals)

### DIFF
--- a/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
+++ b/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
@@ -9,13 +9,16 @@ val GradientShader = RuntimeShader(
     """
         uniform float2 resolution;
         uniform float time;
+        uniform float uSpeed; // 0..1
         
         vec4 main(vec2 fragCoord) {
             // Normalized pixel coordinates (from 0 to 1)
             vec2 uv = fragCoord/resolution.xy;
-    
+            float speedScale = mix(0.1, 2.0, clamp(uSpeed, 0.0, 1.0));
+            float t2 = time * speedScale;   // scaled time
+
             // Time varying pixel color
-            vec3 col = 0.8 + 0.2 * cos(time*2.0+uv.xxx*2.0+vec3(1,2,4));
+            vec3 col = 0.8 + 0.2 * cos(t2*2.0+uv.xxx*2.0+vec3(1,2,4));
     
             // Output to screen
             return vec4(col,1.0);
@@ -30,10 +33,13 @@ val NoodleZoomShader = RuntimeShader(
     """
         uniform float2 resolution;
         uniform float time;
+        uniform float uSpeed; // 0..1
 
         // Source: @notargs https://twitter.com/notargs/status/1250468645030858753
         float f(vec3 p) {
-            p.z -= time * 10.;
+            float speedScale = mix(0.1, 2.0, clamp(uSpeed, 0.0, 1.0));
+            float t2 = time * speedScale;   // scaled time
+            p.z -= t2 * 10.;
             float a = p.z * .1;
             p.xy *= mat2(cos(a), sin(a), -sin(a), cos(a));
             return .1 - length(cos(p.xy) + sin(p.yz));


### PR DESCRIPTION
## Summary
- declare `uSpeed` uniform and derive scaled `t2` in Gradient shader
- declare `uSpeed` uniform and derive scaled `t2` inside Noodle/Doodle zoom shader

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb10ef09148326946bf3e962150a63