### PR TITLE
Gradient: make palette uniform-driven

### DIFF
--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
@@ -14,6 +14,18 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.dp
 import com.goofy.goober.sketch.SketchWithCache
+import kotlin.math.pow
+
+private fun Color.toLinear(): Triple<Float, Float, Float> {
+    fun channel(c: Float): Float {
+        return if (c <= 0.04045f) {
+            c / 12.92f
+        } else {
+            ((c + 0.055f) / 1.055f).toDouble().pow(2.4).toFloat()
+        }
+    }
+    return Triple(channel(red), channel(green), channel(blue))
+}
 
 @Composable
 fun PortalCanvas(
@@ -27,6 +39,12 @@ fun PortalCanvas(
         shader.setFloatUniform("resolution", size.width, size.height)
         shader.setFloatUniform("time", time)
         shader.setFloatUniform("uSpeed", params.speed)
+        val (br, bg, bb) = (params.base ?: Color(0xFFCCCCCC)).toLinear()
+        shader.setFloatUniform("uBase", br, bg, bb)
+        val (ar, ag, ab) = (params.amp ?: Color(0xFF333333)).toLinear()
+        shader.setFloatUniform("uAmp", ar, ag, ab)
+        val phase = params.phase ?: Triple(1f, 2f, 4f)
+        shader.setFloatUniform("uPhase", phase.first, phase.second, phase.third)
         val ringThicknessPx = ringThicknessDp.dp.toPx()
         val ringRadius = size.minDimension / 2f - ringThicknessPx / 2f
         val clipRadius = ringRadius - ringThicknessPx / 2f

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalCanvas.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.dp
 import com.goofy.goober.sketch.SketchWithCache
+import com.goofy.goober.shaders.GradientShader
 import kotlin.math.pow
 
 private fun Color.toLinear(): Triple<Float, Float, Float> {
@@ -39,12 +40,14 @@ fun PortalCanvas(
         shader.setFloatUniform("resolution", size.width, size.height)
         shader.setFloatUniform("time", time)
         shader.setFloatUniform("uSpeed", params.speed)
-        val (br, bg, bb) = (params.base ?: Color(0xFFCCCCCC)).toLinear()
-        shader.setFloatUniform("uBase", br, bg, bb)
-        val (ar, ag, ab) = (params.amp ?: Color(0xFF333333)).toLinear()
-        shader.setFloatUniform("uAmp", ar, ag, ab)
-        val phase = params.phase ?: Triple(1f, 2f, 4f)
-        shader.setFloatUniform("uPhase", phase.first, phase.second, phase.third)
+        if (shader === GradientShader) {
+            val (br, bg, bb) = (params.base ?: Color(0xFFCCCCCC)).toLinear()
+            shader.setFloatUniform("uBase", br, bg, bb)
+            val (ar, ag, ab) = (params.amp ?: Color(0xFF333333)).toLinear()
+            shader.setFloatUniform("uAmp", ar, ag, ab)
+            val phase = params.phase ?: Triple(1f, 2f, 4f)
+            shader.setFloatUniform("uPhase", phase.first, phase.second, phase.third)
+        }
         val ringThicknessPx = ringThicknessDp.dp.toPx()
         val ringRadius = size.minDimension / 2f - ringThicknessPx / 2f
         val clipRadius = ringRadius - ringThicknessPx / 2f

--- a/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalState.kt
+++ b/app/src/main/kotlin/com/goofy/goober/shady/portal/PortalState.kt
@@ -3,8 +3,14 @@ package com.goofy.goober.shady.portal
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 
-data class EffectParams(val speed: Float = 0.5f)
+data class EffectParams(
+    val speed: Float = 0.5f,
+    val base: Color? = null,
+    val amp: Color? = null,
+    val phase: Triple<Float, Float, Float>? = null,
+)
 
 object PortalState {
     var effectId: String = "WARP_TUNNEL"

--- a/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
+++ b/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
@@ -10,6 +10,9 @@ val GradientShader = RuntimeShader(
         uniform float2 resolution;
         uniform float  time;
         uniform float  uSpeed;   // 0..1
+        uniform float3 uBase = float3(0.8, 0.8, 0.8);
+        uniform float3 uAmp  = float3(0.2, 0.2, 0.2);
+        uniform float3 uPhase = float3(1.0, 2.0, 4.0);
         float speedScale = mix(0.1, 2.0, clamp(uSpeed, 0.0, 1.0));
         float t2 = time * speedScale;   // scaled time
 
@@ -18,7 +21,7 @@ val GradientShader = RuntimeShader(
             vec2 uv = fragCoord/resolution.xy;
 
             // Time varying pixel color
-            vec3 col = 0.8 + 0.2 * cos(t2*2.0+uv.xxx*2.0+vec3(1,2,4));
+            vec3 col = uBase + uAmp * cos(t2*2.0+uv.xxx*2.0+uPhase);
 
             // Output to screen
             return vec4(col,1.0);

--- a/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
+++ b/shaders/src/main/kotlin/com/goofy/goober/shaders/Animated.kt
@@ -10,9 +10,9 @@ val GradientShader = RuntimeShader(
         uniform float2 resolution;
         uniform float  time;
         uniform float  uSpeed;   // 0..1
-        uniform float3 uBase = float3(0.8, 0.8, 0.8);
-        uniform float3 uAmp  = float3(0.2, 0.2, 0.2);
-        uniform float3 uPhase = float3(1.0, 2.0, 4.0);
+        uniform float3 uBase;
+        uniform float3 uAmp;
+        uniform float3 uPhase;
         float speedScale = mix(0.1, 2.0, clamp(uSpeed, 0.0, 1.0));
         float t2 = time * speedScale;   // scaled time
 


### PR DESCRIPTION
## Summary
- Make Gradient shader's palette tunable via uBase, uAmp and uPhase uniforms with defaults
- Extend `EffectParams` and wire uniform writes in `PortalCanvas`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4111c5e48326af6dcf4cbd41e688